### PR TITLE
Bumping netmask version to >=2.0.1 fix vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -655,7 +655,6 @@
       "dependencies": {
         "semver": {
           "version": "7.2.1",
-          "bundled": true,
           "dev": true
         }
       }
@@ -7436,10 +7435,9 @@
       "dev": true
     },
     "netmask": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
-      "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.1.tgz",
+      "integrity": "sha512-gB8eG6ubxz67c7O2gaGiyWdRUIbH61q7anjgueDqCC9kvIs/b4CTtCMaQKeJbv1/Y7FT19I4zKwYmjnjInRQsg=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -7650,6 +7648,14 @@
         "ip": "^1.1.5",
         "netmask": "^1.0.6",
         "thunkify": "^2.1.2"
+      },
+      "dependencies": {
+        "netmask": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
+          "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
+          "dev": true
+        }
       }
     },
     "parse-json": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@aws-cdk/aws-s3": "1.32.2",
     "@aws-cdk/core": "1.32.2",
     "@types/uuid": "7.0.2",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.16",
+    "netmask": ">=2.0.1"
   }
 }


### PR DESCRIPTION
Bumping netmask version to >-2.0.1 to fix security vulnerability

*Description of changes:*
This fixes a vulnerability issue by upgrading netmask version to >=2.0.1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
