### PR TITLE
Use `LinuxBuildImage.STANDARD_5_0` as the build image

### DIFF
--- a/lib/pipeline-stack.ts
+++ b/lib/pipeline-stack.ts
@@ -74,7 +74,7 @@ export class PipelineStack extends Stack {
         },
       }),
       environment: {
-        buildImage: LinuxBuildImage.STANDARD_6_0,
+        buildImage: LinuxBuildImage.STANDARD_5_0,
       },
       encryptionKey: key
     });
@@ -101,7 +101,7 @@ export class PipelineStack extends Stack {
         },
       }),
       environment: {
-        buildImage: LinuxBuildImage.STANDARD_6_0,
+        buildImage: LinuxBuildImage.STANDARD_5_0,
       },
       encryptionKey: key
     });

--- a/lib/pipeline-stack.ts
+++ b/lib/pipeline-stack.ts
@@ -74,7 +74,7 @@ export class PipelineStack extends Stack {
         },
       }),
       environment: {
-        buildImage: LinuxBuildImage.AMAZON_LINUX_2_ARM_2,
+        buildImage: LinuxBuildImage.STANDARD_6_0,
       },
       encryptionKey: key
     });
@@ -101,7 +101,7 @@ export class PipelineStack extends Stack {
         },
       }),
       environment: {
-        buildImage: LinuxBuildImage.AMAZON_LINUX_2_ARM_2,
+        buildImage: LinuxBuildImage.STANDARD_6_0,
       },
       encryptionKey: key
     });


### PR DESCRIPTION
* The previously selected image include Node 10 & 12 which does not meet the project requirements.

*Issue #, if available:* #26

*Description of changes:*

This pull request changes the build image in the failing pipeline to use `LinuxBuildImage.STANDARD_5_0` which includes Node 14.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
